### PR TITLE
MpiIsoApp 24.05.3: Bugfix missing lat/long

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: MpiIsoApp
 Title: Pandora & IsoMemo spatiotemporal modeling
-Version: 24.05.2
+Version: 24.05.3
 Authors@R: c(
             person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("cre", "aut")),
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# MpiIsoApp 24.05.3
+
+## Bug Fixes
+- fix for the spread model which was not running if two dates were specified (#218)
+- fixes the case when we have missing longitude or latitude data in the data set (#219)
+
 # MpiIsoApp 24.05.2
 
 ## New Features

--- a/R/01-estimateMap.R
+++ b/R/01-estimateMap.R
@@ -437,7 +437,7 @@ estimateMapSpread <- function(data,
                 DateType = DateType,
                 dateUnc = dateUnc)
   if (all(is.na(data[, DateOne]))) return("non-numeric date field 1 variable")
-  if (DateType != "Single point" && (!all(is.na(data[, DateTwo])))) return("non-numeric date field 2 variable")
+  if (DateType != "Single point" && (all(is.na(data[, DateTwo])))) return("non-numeric date field 2 variable")
 
   # select columns
   data <- na.omit(data[, c("Date", "Uncertainty", Longitude, Latitude)])

--- a/R/01-processCoordinateData.R
+++ b/R/01-processCoordinateData.R
@@ -77,10 +77,10 @@ augmentData <- function(data, restriction = c(-90, 90, -320, 320)) {
 #' @param data (data.frame) data containing columns "Latitude" and "Longitude"
 #' @return (data.frame) data containing columns "Latitude" and "Longitude" shifted to the default restriction
 shiftDataToDefaultRestriction <- function(data) {
-  data$Longitude[data$Longitude > 180] <- data$Longitude[data$Longitude > 180] - 360
-  data$Longitude[data$Longitude < -180] <- data$Longitude[data$Longitude < -180] + 360
-  data$Latitude[data$Latitude > 90] <- data$Latitude[data$Latitude > 90] - 180
-  data$Latitude[data$Latitude < -90] <- data$Latitude[data$Latitude < -90] + 180
+  data$Longitude[data$Longitude > 180 & !is.na(data$Longitude)] <- data$Longitude[data$Longitude > 180 & !is.na(data$Longitude)] - 360
+  data$Longitude[data$Longitude < -180 & !is.na(data$Longitude)] <- data$Longitude[data$Longitude < -180 & !is.na(data$Longitude)] + 360
+  data$Latitude[data$Latitude > 90 & !is.na(data$Latitude)] <- data$Latitude[data$Latitude > 90 & !is.na(data$Latitude)] - 180
+  data$Latitude[data$Latitude < -90 & !is.na(data$Latitude)] <- data$Latitude[data$Latitude < -90 & !is.na(data$Latitude)] + 180
 
   return(data)
 }


### PR DESCRIPTION
This fixes the case when we have missing longitude or latitude data in the data set. It fails currently

-----
# MpiIsoApp 24.05.3

## Bug Fixes
- fix for the spread model which was not running if two dates were specified (#218)
- fixes the case when we have missing longitude or latitude data in the data set (#219)