### PR TITLE
DSSM 24.09.0: Bug/247 error null input

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DSSM
 Title: Pandora & IsoMemo spatiotemporal modeling
-Version: 24.08.5
+Version: 24.09.0
 Authors@R: c(
             person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("cre", "aut")),
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# DSSM 24.09.0
+
+## Bug Fixes
+- fix issue with failing modeling for "Smooth Type" = "planar" with 'number of spatial basis functions' input (#247)
+
 # DSSM 24.08.5
 
 ## New Features

--- a/R/01-estimateMap.R
+++ b/R/01-estimateMap.R
@@ -773,7 +773,9 @@ estimateMap3D <- function(data,
     K <- ceiling(0.9 * nrow(unique(data[, c(Longitude, Latitude)])))
     if (K < 4) {return("less than 4 rows")}
   }
-  if (length(unique(data[, c("Date")])) <= KT) {
+
+  # KT = input[["SmoothingT"]] now can become NULL if splineType != 2
+  if (splineType == 2 && length(unique(data[, c("Date")])) <= KT) {
     KT <- ceiling(0.9 * length(unique(data[, c("Date")])))
     if (KT < 4) {return("less than 4 rows")}
   }


### PR DESCRIPTION
# DSSM 24.09.0

## Bug Fixes
- fix issue with failing modeling for "Smooth Type" = "planar" with 'number of spatial basis functions' input (#247)