### PR TITLE
DSSM 24.09.2: hide center Radius if no center coordinates are set

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DSSM
 Title: Pandora & IsoMemo spatiotemporal modeling
-Version: 24.09.1
+Version: 24.09.2
 Authors@R: c(
             person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("cre", "aut")),
             person("Antonia", "Runge", email = "antonia.runge@inwt-statistics.de", role = c("aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# DSSM 24.09.2
+
+## New Features
+- _Centerpoint estimates_: Radius input is now hidden if the center coordinates are not set (#252)
+
 # DSSM 24.09.1
 
 ## New Features

--- a/R/02-modules-modelResultHelpers.R
+++ b/R/02-modules-modelResultHelpers.R
@@ -12,9 +12,10 @@ centerEstimateUI <- function(id, title = "") {
   ns <- NS(id)
 
   tagList(
+    tags$strong("Center estimates:"),
     numericInput(
       inputId = ns("centerY"),
-      label = "Center point latitude",
+      label = "Latitude",
       min = -180,
       max = 180,
       value = c(),
@@ -23,7 +24,7 @@ centerEstimateUI <- function(id, title = "") {
     ),
     numericInput(
       inputId = ns("centerX"),
-      label = "Center point longitude",
+      label = "Longitude",
       min = -90,
       max = 90,
       value = c(),
@@ -31,27 +32,27 @@ centerEstimateUI <- function(id, title = "") {
       width = "100%"
     ),
     conditionalPanel(
+      ns = ns,
       condition =
         "input.centerY != null && input.centerY != '' && input.centerX != null && input.centerX != '' && output.isCenterEstimateMap == true",
       numericInput(
         inputId = ns("decimalPlace"),
-        label = "Decimal places for Mean/Error at the Center point",
+        label = "Decimal places for Mean/Error",
         min = 0,
         max = 10,
         value = 2,
         step = 1,
         width = "100%"
       ),
-      ns = ns
-    ),
-    sliderInput(
-      inputId = ns("Radius"),
-      label = "Radius (km)",
-      min = 10,
-      max = 300,
-      value = 100,
-      step = 10,
-      width = "100%"
+      sliderInput(
+        inputId = ns("Radius"),
+        label = "Radius (km)",
+        min = 10,
+        max = 300,
+        value = 100,
+        step = 10,
+        width = "100%"
+      )
     )
   )
 }

--- a/R/03-mapDiff.R
+++ b/R/03-mapDiff.R
@@ -349,13 +349,13 @@ modelResultsDiffUI <- function(id, title = ""){
           sliderInput(inputId = ns("ncol"),
                       label = "Approximate number of colour levels",
                       min = 4, max = 50, value = 20, step = 2, width = "100%"),
-          centerEstimateUI(ns("centerEstimateParams")),
           sliderInput(inputId = ns("AxisSize"),
                       label = "Axis title font size",
                       min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
           sliderInput(inputId = ns("AxisLSize"),
                       label = "Axis label font size",
                       min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
+          centerEstimateUI(ns("centerEstimateParams")),
           batchPointEstimatesUI(ns("batch"))
         )
       )

--- a/R/03-mapSim.R
+++ b/R/03-mapSim.R
@@ -221,13 +221,13 @@ modelResultsSimUI <- function(id, title = ""){
           sliderInput(inputId = ns("ncol"),
                       label = "Approximate number of colour levels",
                       min = 4, max = 50, value = 20, step = 2, width = "100%"),
-          centerEstimateUI(ns("centerEstimateParams")),
           sliderInput(inputId = ns("AxisSize"),
                       label = "Axis title font size",
                       min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
           sliderInput(inputId = ns("AxisLSize"),
                       label = "Axis label font size",
                       min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
+          centerEstimateUI(ns("centerEstimateParams")),
           batchPointEstimatesUI(ns("batch"))
         )
       )

--- a/R/03-modelResults2D.R
+++ b/R/03-modelResults2D.R
@@ -373,14 +373,13 @@ modelResults2DUI <- function(id, title = "", asFruitsTab = FALSE){
                       label = "Colour of font",
                       value = "#2C2161")
           , ns = ns),
-        centerEstimateUI(ns("centerEstimateParams")),
         sliderInput(inputId = ns("AxisSize"),
                     label = "Axis title font size",
                     min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
         sliderInput(inputId = ns("AxisLSize"),
                     label = "Axis label font size",
                     min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
-
+        centerEstimateUI(ns("centerEstimateParams")),
         batchPointEstimatesUI(ns("batch"))
       )
     )

--- a/R/03-modelResults2DKernel.R
+++ b/R/03-modelResults2DKernel.R
@@ -338,14 +338,13 @@ modelResults2DKernelUI <- function(id, title = "", asFruitsTab = FALSE){
             colourInput(inputId = ns("fontCol"),
                         label = "Colour of font",
                         value = "#2C2161"), ns = ns),
-          centerEstimateUI(ns("centerEstimateParams")),
           sliderInput(inputId = ns("AxisSize"),
                       label = "Axis title font size",
                       min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
           sliderInput(inputId = ns("AxisLSize"),
                       label = "Axis label font size",
                       min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
-
+          centerEstimateUI(ns("centerEstimateParams")),
           batchPointEstimatesUI(ns("batch"))
         )
       )

--- a/R/03-modelResults3D.R
+++ b/R/03-modelResults3D.R
@@ -444,15 +444,14 @@ modelResults3DUI <- function(id, title = ""){
                       label = "Colour of font",
                       value = "#2C2161")
                       , ns = ns),
-        centerEstimateUI(ns("centerEstimateParams")),
         sliderInput(inputId = ns("AxisSize"),
                     label = "Axis title font size",
                     min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
         sliderInput(inputId = ns("AxisLSize"),
                     label = "Axis label font size",
                     min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
-
-            batchPointEstimatesUI(ns("batch"))
+        centerEstimateUI(ns("centerEstimateParams")),
+        batchPointEstimatesUI(ns("batch"))
         )
     )
   )

--- a/R/03-modelResultsSpread.R
+++ b/R/03-modelResultsSpread.R
@@ -412,13 +412,13 @@ modelResultsSpreadUI <- function(id, title = ""){
             colourInput(inputId = ns("fontCol"),
                         label = "Colour of font",
                         value = "#2C2161"), ns = ns),
-          centerEstimateUI(ns("centerEstimateParams")),
           sliderInput(inputId = ns("AxisSize"),
                       label = "Axis title font size",
                       min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
           sliderInput(inputId = ns("AxisLSize"),
                       label = "Axis label font size",
                       min = 0.1, max = 3, value = 1, step = 0.1, width = "100%"),
+          centerEstimateUI(ns("centerEstimateParams")),
           batchPointEstimatesUI(ns("batch"))
         )
       )


### PR DESCRIPTION
# DSSM 24.09.2

## New Features
- _Centerpoint estimates_: Radius input is now hidden if the center coordinates are not set (#252)