### PR TITLE
DSSM 25.07.1: Bug/276 fix sign error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: DSSM
 Title: Pandora & IsoMemo spatiotemporal modeling
-Version: 25.07.0
+Version: 25.07.1
 Authors@R: c(
             person("Marcus", "Gross", email = "marcus.gross@inwt-statistics.de", role = c("cre", "aut")),
             person("Ricardo", "Fernandes", email = "ldv1452@gmail.com", role = c("aut")),

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get update \
     && rm /tmp/google-chrome.deb \
     && rm -rf /var/lib/apt/lists/*
 
+# Install nimble
+RUN Rscript -e "install.packages('nimble', repos = 'https://packagemanager.posit.co/cran/__linux__/jammy/2025-03-01', version = '1.3.0')"
+
+# Install DSSM & ReSources
 RUN installPackage ReSources \
     && installPackage
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # DSSM 25.07.1
 
 ## Bug Fixes
-- _Calculation of estimates for the map_:
-  - fixed a sign-error in the Metropolis Hastings Algorithm for the date uncertainty (#276)
+- _Estimates for TimeR models_: Fixed a sign-error in the Metropolis Hastings 
+  Algorithm for the date uncertainty
+  - This bug could lead to overly wide estimate ranges (#276)
 
 # DSSM 25.07.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# DSSM 25.07.1
+
+## Bug Fixes
+- _Calculation of estimates for the map_:
+  - fixed a sign-error in the Metropolis Hastings Algorithm for the date uncertainty (#276)
+
 # DSSM 25.07.0
 
 ## Bug Fixes 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # DSSM 25.07.1
 
 ## Bug Fixes
-- _Estimates for TimeR models_: Fixed a sign-error in the Metropolis Hastings 
+- _Estimates for (Bayesian) TimeR models_: Fixed a sign-error in the Metropolis Hastings 
   Algorithm for the date uncertainty
   - This bug could lead to overly wide estimate ranges (#276)
 

--- a/R/01-estimateMap.R
+++ b/R/01-estimateMap.R
@@ -1730,21 +1730,20 @@ cpostX <- function(XX,
                    dateUnc,
                    IndependentType) {
   pred <- XX %*% beta + U %*% gamma
-  if(IndependentType == "numeric"){
-    ret <- (y - pred) ^ 2 / (-2 * sigma.eps)
+  if (IndependentType == "numeric") {
+    ret <- -((y - pred)^2 / (-2 * sigma.eps))
   } else {
-    ret <- log(pred) * y * log(1-pred) * (1-y)
+    ret <- log(pred) * y * log(1 - pred) * (1 - y)
   }
 
-  if(dateUnc == "uniform"){
-    return(ret + log(dunif (
-                xtru,
-                min = xobs - 2 * sqrt(sigma.obs),
-                max = xobs + 2 * sqrt(sigma.obs)
-              ))
-    )
+  if (dateUnc == "uniform") {
+    return(ret + log(dunif(
+      xtru,
+      min = xobs - 2 * sqrt(sigma.obs),
+      max = xobs + 2 * sqrt(sigma.obs)
+    )))
   } else {
-    return(ret + (xobs - xtru) ^ 2 / (-2 * sigma.obs))
+    return(ret - ((xobs - xtru)^2 / (-2 * sigma.obs)))
   }
 }
 

--- a/inst/app/www/info_basis-functions.md
+++ b/inst/app/www/info_basis-functions.md
@@ -15,29 +15,11 @@ longitude and latitude. <br><br>
 - Begin with a small number of basis functions. This prevents overfitting and allows you to model
   the overall trend without capturing too much noise.
 
-**2. Data Complexity**
-
-- **Smooth Data, Simple Relationship**: Fewer basis functions are needed.
-- **Complex Patterns**: If the data has non-linear relationships, many peaks, and troughs, more 
-  basis functions may be required.
-
-**3. Sample Size Consideration**
+**2. Sample Size Consideration**
 
 - The number of basis functions should generally be much smaller than the number of data points.
 - A typical range might be between 5% to 20% of the sample size, depending on the complexity of the data.
 - **Example**: With 100 data points, start with 5 to 20 basis functions.
-
-**4. Avoid Overfitting**
-
-- As you increase the number of basis functions, the risk of overfitting increases.
-- Keep the number low enough to avoid capturing noise in the data.
-
-**Example Guidelines**
-
-- **Low Complexity (e.g., Linear Trend)**: Start with 2-5 basis functions.
-- **Moderate Complexity (e.g., Quadratic or Cubic Trend)**: Consider 5-10 basis functions.
-- **High Complexity (e.g., Highly Non-linear Relationship)**: Explore 10-20 or more basis functions,
-  but monitor for overfitting closely.
 
 **Summary**
 


### PR DESCRIPTION
# DSSM 25.07.1

## Bug Fixes
- _Estimates for (Bayesian) TimeR models_: Fixed a sign-error in the Metropolis Hastings 
  Algorithm for the date uncertainty
  - This bug could lead to overly wide estimate ranges (#276)